### PR TITLE
fix answer file for redstone 2 and later

### DIFF
--- a/answer_files/10/Autounattend.xml
+++ b/answer_files/10/Autounattend.xml
@@ -94,6 +94,7 @@
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
                 <NetworkLocation>Home</NetworkLocation>
                 <ProtectYourPC>1</ProtectYourPC>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
             </OOBE>
             <AutoLogon>
                 <Password>


### PR DESCRIPTION
Fixes the build for redstone 2 and later:
![Capture d’écran de 2020-03-27 12-46-52](https://user-images.githubusercontent.com/964610/77794223-c8bf1900-706b-11ea-83f4-6efd8cd7bbb3.png)


Use an undocumented parameter un Autounattended.xml

Official documentation for OOBE section:
https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-oobe

cc @milenkowski